### PR TITLE
Fix delete-temporary-files undefined variable

### DIFF
--- a/src/smart-buffer.lisp
+++ b/src/smart-buffer.lisp
@@ -111,5 +111,5 @@
   (let ((now (get-universal-time)))
     (mapc #'uiop:delete-file-if-exists
           (remove-if-not (lambda (file)
-                           (< before (- now (file-write-date file))))
+                           (< stale-seconds (- now (file-write-date file))))
                          (uiop:directory-files *temporary-directory*)))))


### PR DESCRIPTION
Fixes #2. The function `delete-temporary-files` deletes all files within
`*temporary-directory*` that are older than `stale-seconds` (default 0).
Some time ago, the argument `before` was renamed to `stale seconds` (or
vice versa), but wasn't changed everywhere else. This change fixes the
issue, reducing the noise made by `(require)` whenever any dependents
load this system.

Signed-off-by: Samuel Hunter <samuel@shunter.xyz>